### PR TITLE
Implemented base palette grid

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,3 +11,13 @@
   flex-direction: row;
   gap: 48px;
 }
+
+.App .palette {
+  display: flex;
+  flex-direction: column;
+}
+
+.App .compute-btn {
+  padding: 4px;
+  margin: 12px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import './App.css';
 import { BaseColorControls } from './Components/BaseColorControls';
 import { BaseColorsPreview } from './Components/BaseColorsPreview';
+import { ShadesGridPreview } from './Components/ShadesGridPreview';
+import { computeShadesGrid } from './utils/computeShadesGrid';
+import { getEmptyShadesGrid } from './utils/getEmptyShadesGrid';
 
 const initialColors = [
   '#ffffff', //white
@@ -14,7 +17,11 @@ const initialColors = [
   '#000000', //black
 ];
 
+const emptyShades = getEmptyShadesGrid(initialColors.length);
+
 function App() {
+  const [darkerShades, setDarkerShades] = useState([...emptyShades]);
+  const [lighterShades, setLighterShades] = useState([...emptyShades]);
   const [baseColors, setBaseColors] = useState(initialColors);
 
   const handleColorChange = (index: number, color: string) => {
@@ -23,13 +30,37 @@ function App() {
     setBaseColors(newColors);
   };
 
+  const handleComputeShades = () => {
+    const { darkerGridColors, lighterGridColors } = computeShadesGrid(
+      baseColors,
+      6
+    );
+    setDarkerShades(darkerGridColors);
+    setLighterShades(lighterGridColors);
+  };
+
   return (
     <div className="App">
       <BaseColorControls
         initialColors={initialColors}
         onColorChange={handleColorChange}
       />
-      <BaseColorsPreview colors={baseColors} />
+      <div>
+        <div className="palette">
+          <ShadesGridPreview
+            colors={lighterShades}
+            columnCount={initialColors.length}
+          />
+          <BaseColorsPreview colors={baseColors} />
+          <ShadesGridPreview
+            colors={darkerShades}
+            columnCount={initialColors.length}
+          />
+        </div>
+        <button className="compute-btn" onClick={handleComputeShades}>
+          Compute Palette
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/Components/BaseColorsPreview/index.tsx
+++ b/src/Components/BaseColorsPreview/index.tsx
@@ -7,7 +7,10 @@ type Props = {
 
 export function BaseColorsPreview({ colors }: Props) {
   return (
-    <div className="base-palette-grid">
+    <div
+      className="base-palette-grid"
+      style={{ gridTemplateColumns: `repeat(${colors.length}, 1fr)` }}
+    >
       {colors.map((color) => (
         <ColorPreview key={color} color={color} />
       ))}

--- a/src/Components/BaseColorsPreview/styles.css
+++ b/src/Components/BaseColorsPreview/styles.css
@@ -1,6 +1,5 @@
 .base-palette-grid {
   display: grid;
-  grid-template-columns: repeat(8, 1fr);
 }
 
 .base-palette-grid > .color-preview {

--- a/src/Components/ShadesGridPreview/index.tsx
+++ b/src/Components/ShadesGridPreview/index.tsx
@@ -1,0 +1,29 @@
+import { nanoid } from 'nanoid';
+import { useMemo } from 'react';
+import { ColorPreview } from '../ColorPreview';
+import './styles.css';
+
+type Props = {
+  colors: string[];
+  columnCount: number;
+};
+
+export function ShadesGridPreview({ colors, columnCount }: Props) {
+  const keyIds = useMemo(() => {
+    const ids: string[] = [];
+    for (let i = 0; i < colors.length; i++) {
+      ids.push(nanoid(12));
+    }
+    return ids;
+  }, [columnCount]);
+  return (
+    <div
+      className="shades-grid"
+      style={{ gridTemplateColumns: `repeat(${columnCount}, 1fr)` }}
+    >
+      {colors.map((color, index) => (
+        <ColorPreview key={keyIds[index]} color={color} />
+      ))}
+    </div>
+  );
+}

--- a/src/Components/ShadesGridPreview/styles.css
+++ b/src/Components/ShadesGridPreview/styles.css
@@ -1,0 +1,14 @@
+.shades-grid {
+  display: grid;
+}
+
+.shades-grid > .color-preview {
+  box-sizing: border-box;
+  height: 40px;
+  width: 40px;
+}
+
+.shades-grid > .color-preview:hover {
+  border-width: 1px;
+  border-style: solid;
+}

--- a/src/utils/computeShades.ts
+++ b/src/utils/computeShades.ts
@@ -1,0 +1,52 @@
+import { darken, lighten, parseToHsl } from 'polished';
+
+export function computeShades(
+  color: string,
+  numberOfShades: number,
+  maxShades = 6
+) {
+  if (numberOfShades > maxShades) {
+    throw new Error(
+      `number of shades ${numberOfShades} must not be greater than max shades ${maxShades}`
+    );
+  }
+
+  const { lightness } = parseToHsl(color);
+  const deltaChange = 1 / (numberOfShades + 1);
+  const darkerShades: string[] = [];
+  const lighterShades: string[] = [];
+  let darkerLuminance = lightness;
+  let lighterLuminance = lightness;
+  let count = 0;
+
+  while (
+    lighterShades.length + darkerShades.length < numberOfShades &&
+    count < maxShades
+  ) {
+    if (darkerLuminance >= 0.2) {
+      darkerLuminance += deltaChange;
+      darkerShades.push(darken(deltaChange * (darkerShades.length + 1), color));
+    }
+
+    if (lighterLuminance <= 0.8) {
+      lighterLuminance += deltaChange;
+      lighterShades.unshift(
+        lighten(deltaChange * (lighterShades.length + 1), color)
+      );
+    }
+
+    count++;
+  }
+
+  const fillerDarkerShades = maxShades - darkerShades.length;
+  for (let i = 0; i < fillerDarkerShades; i++) {
+    darkerShades.push('rgb(0, 0, 0, 0)');
+  }
+
+  const fillerLighterShades = maxShades - lighterShades.length;
+  for (let i = 0; i < fillerLighterShades; i++) {
+    lighterShades.unshift('rgb(0, 0, 0, 0)');
+  }
+
+  return { darkerShades, lighterShades };
+}

--- a/src/utils/computeShades.ts
+++ b/src/utils/computeShades.ts
@@ -1,5 +1,9 @@
 import { darken, lighten, parseToHsl } from 'polished';
 
+const transparentColor = 'rgb(0, 0, 0, 0)';
+const higherLightnessThreshold = 0.8;
+const lowerLightnessThreshold = 0.2;
+
 export function computeShades(
   color: string,
   numberOfShades: number,
@@ -23,12 +27,12 @@ export function computeShades(
     lighterShades.length + darkerShades.length < numberOfShades &&
     count < maxShades
   ) {
-    if (darkerLuminance >= 0.2) {
+    if (darkerLuminance >= lowerLightnessThreshold) {
       darkerLuminance += deltaChange;
       darkerShades.push(darken(deltaChange * (darkerShades.length + 1), color));
     }
 
-    if (lighterLuminance <= 0.8) {
+    if (lighterLuminance <= higherLightnessThreshold) {
       lighterLuminance += deltaChange;
       lighterShades.unshift(
         lighten(deltaChange * (lighterShades.length + 1), color)
@@ -40,12 +44,12 @@ export function computeShades(
 
   const fillerDarkerShades = maxShades - darkerShades.length;
   for (let i = 0; i < fillerDarkerShades; i++) {
-    darkerShades.push('rgb(0, 0, 0, 0)');
+    darkerShades.push(transparentColor);
   }
 
   const fillerLighterShades = maxShades - lighterShades.length;
   for (let i = 0; i < fillerLighterShades; i++) {
-    lighterShades.unshift('rgb(0, 0, 0, 0)');
+    lighterShades.unshift(transparentColor);
   }
 
   return { darkerShades, lighterShades };

--- a/src/utils/computeShadesGrid.ts
+++ b/src/utils/computeShadesGrid.ts
@@ -1,0 +1,32 @@
+import { computeShades } from './computeShades';
+
+export function computeShadesGrid(
+  colors: string[],
+  numberOfShades: number,
+  maxShades = 6
+) {
+  const darkerColors: string[][] = [];
+  const lighterColors: string[][] = [];
+
+  for (const color of colors) {
+    const { darkerShades, lighterShades } = computeShades(
+      color,
+      numberOfShades,
+      maxShades
+    );
+    darkerColors.push(darkerShades);
+    lighterColors.push(lighterShades);
+  }
+
+  const darkerGridColors: string[] = [];
+  const lighterGridColors: string[] = [];
+
+  for (let i = 0; i < maxShades; i++) {
+    for (let j = 0; j < colors.length; j++) {
+      darkerGridColors.push(darkerColors[j][i]);
+      lighterGridColors.push(lighterColors[j][i]);
+    }
+  }
+
+  return { darkerGridColors, lighterGridColors };
+}

--- a/src/utils/getEmptyShadesGrid.ts
+++ b/src/utils/getEmptyShadesGrid.ts
@@ -1,0 +1,10 @@
+export function getEmptyShadesGrid(totalColors: number, maxShades = 6) {
+  const shadesGrid: string[] = [];
+  for (let i = 0; i < maxShades; i++) {
+    for (let j = 0; j < totalColors; j++) {
+      shadesGrid.push('rgba(0, 0, 0, 0)');
+    }
+  }
+
+  return shadesGrid;
+}


### PR DESCRIPTION
### Changes
- Added util functions for:
  - Computing an empty shades grid
  - Computing the shades for a base color
  - Arranging the colors in two grids: one for lighter shades and the other for darker shades
- Added ShadesGridPreview component
- Updated BaseColorsPreview to display a number of columns equal to the number of colors
- Added a button to compute the shades