### PR TITLE
Removed limit of computed vertical shades

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,12 +47,12 @@ function App() {
   };
 
   const computeShades = (colors: readonly string[]) => {
-    const baseShades = computeShadesGrid(colors, 6);
+    const baseShades = computeShadesGrid(colors);
     setDarkerShades(baseShades.darkerGridColors);
     setLighterShades(baseShades.lighterGridColors);
 
     const inBetweenColors = computeDerivedColors(colors);
-    const derivedShades = computeShadesGrid(inBetweenColors, 4);
+    const derivedShades = computeShadesGrid(inBetweenColors);
     setDerivedColors(inBetweenColors);
     setDerivedDarkerShades(derivedShades.darkerGridColors);
     setDerivedLighterShades(derivedShades.lighterGridColors);

--- a/src/utils/computeShades.ts
+++ b/src/utils/computeShades.ts
@@ -6,7 +6,9 @@ const lowerLightnessThreshold = 0.2;
 
 export function computeShades(color: string, maxShades = 6) {
   const { lightness } = parseToHsl(color);
-  const deltaChange = 1 / (maxShades * 2 + 1);
+  // max lighter shades plus max darker shades plus the base color row
+  const totalVerticalColors = maxShades * 2 + 1;
+  const deltaChange = 1 / totalVerticalColors;
   const darkerShades: string[] = [];
   const lighterShades: string[] = [];
   let darkerLuminance = lightness;

--- a/src/utils/computeShades.ts
+++ b/src/utils/computeShades.ts
@@ -4,29 +4,15 @@ import { TRANSPARENT_COLOR } from './constants';
 const higherLightnessThreshold = 0.8;
 const lowerLightnessThreshold = 0.2;
 
-export function computeShades(
-  color: string,
-  numberOfShades: number,
-  maxShades = 6
-) {
-  if (numberOfShades > maxShades) {
-    throw new Error(
-      `number of shades ${numberOfShades} must not be greater than max shades ${maxShades}`
-    );
-  }
-
+export function computeShades(color: string, maxShades = 6) {
   const { lightness } = parseToHsl(color);
-  const deltaChange = 1 / (numberOfShades + 1);
+  const deltaChange = 1 / (maxShades * 2 + 1);
   const darkerShades: string[] = [];
   const lighterShades: string[] = [];
   let darkerLuminance = lightness;
   let lighterLuminance = lightness;
-  let count = 0;
 
-  while (
-    lighterShades.length + darkerShades.length < numberOfShades &&
-    count < maxShades
-  ) {
+  for (let i = 0; i < maxShades; i++) {
     if (darkerLuminance >= lowerLightnessThreshold) {
       darkerLuminance += deltaChange;
       darkerShades.push(darken(deltaChange * (darkerShades.length + 1), color));
@@ -38,8 +24,6 @@ export function computeShades(
         lighten(deltaChange * (lighterShades.length + 1), color)
       );
     }
-
-    count++;
   }
 
   const fillerDarkerShades = maxShades - darkerShades.length;

--- a/src/utils/computeShadesGrid.ts
+++ b/src/utils/computeShadesGrid.ts
@@ -1,19 +1,11 @@
 import { computeShades } from './computeShades';
 
-export function computeShadesGrid(
-  colors: readonly string[],
-  numberOfShades: number,
-  maxShades = 6
-) {
+export function computeShadesGrid(colors: readonly string[], maxShades = 6) {
   const darkerColors: string[][] = [];
   const lighterColors: string[][] = [];
 
   for (const color of colors) {
-    const { darkerShades, lighterShades } = computeShades(
-      color,
-      numberOfShades,
-      maxShades
-    );
+    const { darkerShades, lighterShades } = computeShades(color, maxShades);
     darkerColors.push(darkerShades);
     lighterColors.push(lighterShades);
   }


### PR DESCRIPTION
### Changes
Removed the limit 6 and 4 combined number of darker and lighter shades. Now it will compute until it fills all available vertical color shades. The maximum for either direction is still 6. Adjusted also the delta step for the shade because the parameter it used got removed. The delta step is now 1 / the total of available vertical slots