### PR TITLE
Implemented color controls restrictions

### DIFF
--- a/src/Components/BaseColorControls/constants.ts
+++ b/src/Components/BaseColorControls/constants.ts
@@ -1,0 +1,65 @@
+type HslRestriction = {
+  minHue: number;
+  maxHue: number;
+  minLightness: number;
+  maxLightness: number;
+};
+
+export const ControlRestrictions: readonly HslRestriction[] = [
+  // white
+  {
+    minHue: 0,
+    maxHue: 360,
+    minLightness: 0.8,
+    maxLightness: 1,
+  },
+  // red
+  {
+    minHue: -30,
+    maxHue: 30,
+    minLightness: 0.2,
+    maxLightness: 0.8,
+  },
+  // yellow
+  {
+    minHue: 30,
+    maxHue: 90,
+    minLightness: 0.2,
+    maxLightness: 0.8,
+  },
+  // green
+  {
+    minHue: 90,
+    maxHue: 150,
+    minLightness: 0.2,
+    maxLightness: 0.8,
+  },
+  // cyan
+  {
+    minHue: 150,
+    maxHue: 210,
+    minLightness: 0.2,
+    maxLightness: 0.8,
+  },
+  // blue
+  {
+    minHue: 210,
+    maxHue: 270,
+    minLightness: 0.2,
+    maxLightness: 0.8,
+  },
+  // magenta
+  {
+    minHue: 270,
+    maxHue: 330,
+    minLightness: 0.2,
+    maxLightness: 0.8,
+  },
+  // black
+  {
+    minHue: 0,
+    maxHue: 360,
+    minLightness: 0,
+    maxLightness: 0.2,
+  },
+];

--- a/src/Components/BaseColorControls/index.tsx
+++ b/src/Components/BaseColorControls/index.tsx
@@ -1,4 +1,5 @@
 import { HslColorControl } from '../HslColorControl';
+import { ControlRestrictions } from './constants';
 import './styles.css';
 
 type Props = {
@@ -11,6 +12,7 @@ export function BaseColorControls({ initialColors, onColorChange }: Props) {
     <div className="color-controls">
       {initialColors.map((color, index) => (
         <HslColorControl
+          {...ControlRestrictions[index]}
           key={color}
           initialColor={color}
           onColorChange={(color) => {

--- a/src/Components/HslColorControl/LabeledSlider.tsx
+++ b/src/Components/HslColorControl/LabeledSlider.tsx
@@ -19,6 +19,7 @@ export function LabeledSlider({
   onChange,
 }: Props) {
   const [id] = useState(nanoid(10));
+  const formattedValue = step < 1 ? (value * 100).toFixed() : value;
   return (
     <div className="slider-container">
       <label htmlFor={id} className="label">
@@ -34,6 +35,7 @@ export function LabeledSlider({
         value={value}
         onChange={(e) => onChange(parseFloat(e.target.value))}
       />
+      <span className="value">({formattedValue})</span>
     </div>
   );
 }

--- a/src/Components/HslColorControl/index.tsx
+++ b/src/Components/HslColorControl/index.tsx
@@ -7,11 +7,22 @@ import { LabeledSlider } from './LabeledSlider';
 import './styles.css';
 
 type Props = {
+  minHue: number;
+  maxHue: number;
+  minLightness: number;
+  maxLightness: number;
   initialColor: string;
   onColorChange: (color: string) => void;
 };
 
-export function HslColorControl({ initialColor, onColorChange }: Props) {
+export function HslColorControl({
+  minHue,
+  maxHue,
+  minLightness,
+  maxLightness,
+  initialColor,
+  onColorChange,
+}: Props) {
   const hslColor = parseToHsl(initialColor);
   const [hue, setHue] = useState(hslColor.hue);
   const [saturation, setSaturation] = useState(hslColor.saturation);
@@ -44,14 +55,14 @@ export function HslColorControl({ initialColor, onColorChange }: Props) {
       <ColorPreview color={color} />
       <div className="sliders">
         <LabeledSlider
-          label="Hue"
-          min={0}
-          max={360}
+          label="H"
+          min={minHue}
+          max={maxHue}
           value={hue}
           onChange={handleHueChange}
         />
         <LabeledSlider
-          label="Sat"
+          label="S"
           min={0}
           max={1}
           step={0.01}
@@ -59,9 +70,9 @@ export function HslColorControl({ initialColor, onColorChange }: Props) {
           onChange={handleSaturationChange}
         />
         <LabeledSlider
-          label="Lig"
-          min={0}
-          max={1}
+          label="L"
+          min={minLightness}
+          max={maxLightness}
           step={0.01}
           value={lightness}
           onChange={handleLightnessChange}

--- a/src/Components/HslColorControl/styles.css
+++ b/src/Components/HslColorControl/styles.css
@@ -28,9 +28,14 @@
 
 .slider-container > .label {
   text-align: right;
-  width: 32px;
+  width: 12px;
 }
 
 .slider-container > .slider {
-  width: 132px;
+  text-align: right;
+  width: 128px;
+}
+
+.slider-container > .value {
+  width: 36px;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -39,7 +39,7 @@ export const columnBaseHeaders = Object.freeze([
   'c',
   'b',
   'm',
-  'b',
+  'k',
 ]);
 
 export const columnDerivedHeaders = Object.freeze([


### PR DESCRIPTION
### Changes
- Fixed header name for the black color column. It comes from the CMYK where the K stands for key, usually the black color as the key color
- Defined in constants the value restrictions for the Color Controls
- Implemented the value restrictions for the color controls
- Changed the labels to just H, S, and L
- Added a value display for the sliders