### PR TITLE
Resized palette grid for mobile view

### DIFF
--- a/src/Components/GridHeader/styles.css
+++ b/src/Components/GridHeader/styles.css
@@ -8,3 +8,10 @@
   height: 40px;
   width: 40px;
 }
+
+@media (max-width: 644px) {
+  .grid-header > .title {
+    height: 32px;
+    width: 32px;
+  }
+}

--- a/src/Components/PaletteGrid/styles.css
+++ b/src/Components/PaletteGrid/styles.css
@@ -12,3 +12,10 @@
   border-width: 1px;
   border-style: solid;
 }
+
+@media (max-width: 644px) {
+  .palette-grid > .color-preview {
+    height: 32px;
+    width: 32px;
+  }
+}


### PR DESCRIPTION
### Bugfix
The palette grid was bigger than the available space on mobile view. Resized the cells to make the grid fit